### PR TITLE
fix prettier version discrepancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "build": "pnpm run prettify && pnpm run build:types && pnpm run test:suite",
         "build:types": "tsc -p jsconfig.json --noEmit false --emitDeclarationOnly",
+        "lockfile:sync": "pnpm install --ignore-workspace ; rm -rf node_modules ;  pnpm install",
         "prepack": "pnpm run build",
         "prettify": "prettier . --write",
         "test": "pnpm run test:pretty && pnpm run test:types && pnpm run test:suite",
@@ -25,7 +26,7 @@
     },
     "devDependencies": {
         "@types/node": "^20.10.0",
-        "prettier": "^3.1.0",
+        "prettier": "^3.3.3",
         "typescript": "^5.3.2"
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^20.10.0
         version: 20.16.5
       prettier:
-        specifier: ^3.1.0
+        specifier: ^3.3.3
         version: 3.3.3
       typescript:
         specifier: ^5.3.2

--- a/src/bytes/base32.js
+++ b/src/bytes/base32.js
@@ -37,7 +37,7 @@ export class Base32 {
     constructor(props = Base32.DEFAULT_PROPS) {
         const alphabet = props.alphabet ?? Base32.DEFAULT_ALPHABET
         const padChar = "padChar" in props ? props.padChar : ""
-        const strict = "strict" in props ? props.strict ?? false : false
+        const strict = "strict" in props ? (props.strict ?? false) : false
 
         if (alphabet.length != 32) {
             throw new Error(

--- a/src/bytes/base64.js
+++ b/src/bytes/base64.js
@@ -37,7 +37,7 @@ export class Base64 {
     constructor(props = Base64.DEFAULT_PROPS) {
         const alphabet = props.alphabet ?? Base64.DEFAULT_ALPHABET
         const padChar = "padChar" in props ? props.padChar : ""
-        const strict = "strict" in props ? props.strict ?? false : false
+        const strict = "strict" in props ? (props.strict ?? false) : false
 
         if (alphabet.length != 64) {
             throw new Error(


### PR DESCRIPTION
Some of the other packages require prettier 3.3, and pnpm was satisfied by that version for this package's need, though 3.1 was also allowable here - thus our different versions of prettier can fight over formatting.

This should correct it, even if you're not always using the workspace-centric `pnpm i`.